### PR TITLE
Load the config from the environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,6 @@ dump.rdb
 
 .vagrant
 
+.lein-env
+
 cloujera.log

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ videos on [coursera](http://coursera.org).
 $ vagrant ssh
 $ cd /vagrant
 $ source ./scripts/prod-env.sh
-$ rm ./profiles.clj # and restore with git checkout later
 $ ./scripts/deploy.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,16 @@ videos on [coursera](http://coursera.org).
 ```bash
 $ vagrant ssh
 $ cd /vagrant
+$ source ./scripts/prod-env.sh
+$ rm ./profiles.clj # and restore with git checkout later
 $ ./scripts/deploy.sh
 ```
 
 **NOTE:** the address to access the uberjarred cloujera running on port `8080`
  is `http://127.0.0.1:8081` (see `Vagrantfile`)
+
+**FIXME**: the sourcing of prod-env.sh is just a temporary fix while we move to
+docker ....
 
 
 ## Scraping courses
@@ -72,6 +77,7 @@ $ sudo ./scripts/provision.sh
 
 ```bash
 # in the cloujera directory...
+$ source ./scripts/prod-env.sh
 $ ./scripts/deploy.sh
 ```
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 6379, host: 6379
 
   # Cloujera port
-  config.vm.network "forwarded_port", guest: 8080, host: 8081
+  config.vm.network "forwarded_port", guest: 8080, host: 8081 # for lein run/uberjar inside VM
 
   # provisioning: docker, elasticsearch, redis
   config.vm.provision "shell", path: "./scripts/provision.sh"

--- a/profiles.clj
+++ b/profiles.clj
@@ -1,0 +1,8 @@
+;;; profiles.clj contains the values for the `:dev` profile (`lein repl`).
+;;; This file is looked up before the actual environment
+;;; used by environ, merged with project.clj map
+
+;; we define :elasticsearch-port and :redis-port with weird names and format
+;; because that's the the ones Docker exports in linked containers
+{:dev {:env {:elasticsearch-port "tcp://127.0.0.1:9200"
+             :redis-port "tcp://127.0.0.1:9300"}}}

--- a/project.clj
+++ b/project.clj
@@ -19,10 +19,13 @@
 
                  [cheshire "5.4.0"] ;; JSON deserializing
 
+                 [environ "1.0.0"] ;; for loading env vars
+
                  [clojurewerkz/elastisch "2.1.0"] ;; for persitance
                  [com.taoensso/carmine "2.9.0"]] ;; for caching
 
-  :plugins [[lein-cljsbuild "1.0.4"]]
+  :plugins [[lein-cljsbuild "1.0.4"]
+            [lein-environ "1.0.0"]]
 
   :min-lein-version "2.0.0"
 

--- a/scripts/prod-env.sh
+++ b/scripts/prod-env.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export ELASTICSEARCH_PORT="tcp://127.0.0.1:9200"
+export REDIS_PORT="tcp://127.0.0.1:9300"

--- a/src/clj/cloujera/cache/core.clj
+++ b/src/clj/cloujera/cache/core.clj
@@ -1,12 +1,22 @@
 (ns cloujera.cache.core
-  (:require [taoensso.carmine :as redis]))
+  (:require [taoensso.carmine :as redis]
+            [environ.core :refer [env]]
+            [clojure.string :as string]))
+
+(defn conn []
+  (let [redis-tcp-uri (env :redis-port)
+        redis-uri (.replaceAll redis-tcp-uri
+                               "^tcp://" "")
+        [host port] (string/split redis-uri #":")]
+    {:host host
+     :port (Integer. port)}))
 
 (defn persist [f]
   (fn [k]
-    (let [cached-val (redis/wcar {} (redis/get k))]
+    (let [cached-val (redis/wcar (conn) (redis/get k))]
          (if (nil? cached-val)
            (let [computed-val (f k)]
-             (redis/wcar {} (redis/set k computed-val))
+             (redis/wcar (conn) (redis/set k computed-val))
              computed-val)
            cached-val))))
 

--- a/src/clj/cloujera/search/core.clj
+++ b/src/clj/cloujera/search/core.clj
@@ -3,9 +3,14 @@
             [clojurewerkz.elastisch.query :as q]
             [clojurewerkz.elastisch.rest :as esr]
             [clojurewerkz.elastisch.rest.document :as esd]
+            [environ.core :refer [env]]
             [cloujera.models.video :as video]))
 
-(def conn (esr/connect "http://127.0.0.1:9200"))
+(defn conn []
+  (let [elasticsearch-tcp-uri (env :elasticsearch-port)
+        elasticsearch-uri (.replaceAll elasticsearch-tcp-uri
+                                       "^tcp:" "http:")]
+    (esr/connect elasticsearch-uri)))
 
 ;;;;;;;;;;;;;;;;;;;;
 ;; PRIVATE INTERFACE
@@ -34,15 +39,15 @@
 
 (defn save [video]
   (let [identifier (generate-id video)]
-    (esd/put conn "videos" "video" identifier video) video))
+    (esd/put (conn) "videos" "video" identifier video) video))
 
 
 (defn term-matching [term]
-  (extract-results (esd/search conn "videos" "video"
+  (extract-results (esd/search (conn) "videos" "video"
                                :query (q/match :transcript term)
                                :highlight {:fields {:transcript {}}})))
 
 (defn all []
-  (extract-results (esd/search conn "videos" "video" :query (q/match-all {}))))
+  (extract-results (esd/search (conn) "videos" "video" :query (q/match-all {}))))
 
 


### PR DESCRIPTION
- uses dev profile in profiles.clj with `lein repl`
- use `source ./scripts/prod-env.sh` for uberjar
- this is in preparation for fully Dockerizing cloujera
