### PR TITLE
[RFC] Dockerize cloujera

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM java:7
+
+ADD ./target/uberjar/cloujera-0.1.0-SNAPSHOT-standalone.jar /srv/cloujera.jar
+
+EXPOSE 8080
+
+CMD ["java", "-jar", "/srv/cloujera.jar"]

--- a/README.md
+++ b/README.md
@@ -20,21 +20,30 @@ videos on [coursera](http://coursera.org).
    (it will error out ridiculously with an `IndexMissingException` from
    elasticsearch if you don't do this!);
 
+### Testing dockerized cloujera inside Vagrant VM
 
-## Testing uberjar inside Vagrant
+```bash
+$ vagrant ssh
+$ cd /vagrant
+$ ./scripts/deploy.sh
+```
+
+**NOTE:** the address to access the dockerized cloujera is
+`http://127.0.0.1:8081` (see `Vagrantfile`)
+
+
+### Testing uberjar inside Vagrant
 
 ```bash
 $ vagrant ssh
 $ cd /vagrant
 $ source ./scripts/prod-env.sh
-$ ./scripts/deploy.sh
+$ lein uberjar
+$ java -jar ./target/uberjar/cloujera-*-standalone.jar
 ```
 
 **NOTE:** the address to access the uberjarred cloujera running on port `8080`
- is `http://127.0.0.1:8081` (see `Vagrantfile`)
-
-**FIXME**: the sourcing of prod-env.sh is just a temporary fix while we move to
-docker ....
+is `http://127.0.0.1:8082` (see `Vagrantfile`)
 
 
 ## Scraping courses
@@ -76,7 +85,6 @@ $ sudo ./scripts/provision.sh
 
 ```bash
 # in the cloujera directory...
-$ source ./scripts/prod-env.sh
 $ ./scripts/deploy.sh
 ```
 
@@ -92,13 +100,14 @@ $ vagrant ssh
 $ sudo docker ps -a
 ```
 
-You should see `redis` and `elasticsearch` running
+You should see `redis`, `elasticsearch` and `cloujera` running
 
 
 ### Checking the cloujera logs
 
 ```bash
-$ cat cloujera.log
+$ vagrant ssh
+$ sudo docker exec cloujera cat /var/cloujera.log
 ```
 
 ### Checking elasticsearch health
@@ -112,6 +121,13 @@ Visit `http://localhost:9200/`, you should see `status: 200`
 `MONITOR`, `HELP`, `HELP @server`.
 
 **NOTE**: this works form the host as well as in the Vagrant VM
+
+
+### Dropping into a shell inside a container
+```bash
+$ vagrant ssh || ssh user@cloudbox
+$ sudo docker exec -i -t cloujera bash
+```
 
 
 # BUGS

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network "forwarded_port", guest: 6379, host: 6379
 
   # Cloujera port
-  config.vm.network "forwarded_port", guest: 8080, host: 8081 # for lein run/uberjar inside VM
+  config.vm.network "forwarded_port", guest: 80, host: 8081 # for cloujera Docker container
+  config.vm.network "forwarded_port", guest: 8080, host: 8082 # for lein run/uberjar inside VM
 
   # provisioning: docker, elasticsearch, redis
   config.vm.provision "shell", path: "./scripts/provision.sh"

--- a/profiles.clj
+++ b/profiles.clj
@@ -5,4 +5,4 @@
 ;; we define :elasticsearch-port and :redis-port with weird names and format
 ;; because that's the the ones Docker exports in linked containers
 {:dev {:env {:elasticsearch-port "tcp://127.0.0.1:9200"
-             :redis-port "tcp://127.0.0.1:9300"}}}
+             :redis-port "tcp://127.0.0.1:6379"}}}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,14 @@
 set -euo pipefail
 IFS=$'\n\t'
 
+sudo -v
+
+cloujera_container_name="cloujera"
+cloujera_image_tag=$cloujera_container_name
+
+echo "==> Removing existing cloujera container"
+sudo docker rm -f $cloujera_container_name || true
+
 echo "==> pulling most recent version (git)"
 # FIXME: it would be nice to checkout to avoid weird
 # stuff happening, but it's really easy to run this
@@ -16,5 +24,14 @@ lein cljsbuild once
 echo "==> Uberjarring"
 lein uberjar
 
-echo "==> Running cloujera"
-java -jar ./target/uberjar/cloujera-0.1.0-SNAPSHOT-standalone.jar > cloujera.log 2>&1
+echo "==> Building container"
+sudo docker build --tag $cloujera_image_tag ./
+
+echo "==> Running container"
+sudo docker run \
+   --detach \
+   --publish 80:8080 \
+   --name $cloujera_container_name \
+   --link redis:redis \
+   --link elasticsearch:elasticsearch \
+   $cloujera_image_tag

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,9 +7,6 @@ sudo -v
 cloujera_container_name="cloujera"
 cloujera_image_tag=$cloujera_container_name
 
-echo "==> Removing existing cloujera container"
-sudo docker rm -f $cloujera_container_name || true
-
 echo "==> pulling most recent version (git)"
 # FIXME: it would be nice to checkout to avoid weird
 # stuff happening, but it's really easy to run this
@@ -24,8 +21,11 @@ lein cljsbuild once
 echo "==> Uberjarring"
 lein uberjar
 
-echo "==> Building container"
+echo "==> Building new cloujera container"
 sudo docker build --tag $cloujera_image_tag ./
+
+echo "==> Removing existing cloujera container"
+sudo docker rm -f $cloujera_container_name || true
 
 echo "==> Running container"
 sudo docker run \

--- a/src/clj/cloujera/cache/core.clj
+++ b/src/clj/cloujera/cache/core.clj
@@ -8,8 +8,8 @@
         redis-uri (.replaceAll redis-tcp-uri
                                "^tcp://" "")
         [host port] (string/split redis-uri #":")]
-    {:host host
-     :port (Integer. port)}))
+    {:spec {:host host
+            :port (Integer. port)}}))
 
 (defn persist [f]
   (fn [k]


### PR DESCRIPTION
The final piece of the puzzle.

After checking that cloujera works at every step:
- #2 cleaning up and removing hardcoded backend string from CLJS;
- #3 running elasticsearch and redis in a VM with forwarded ports; and
- #4 loading the configs from the environment;
- a few commits along the way, most notably 70e07d10229a4e61ec24fc9324cad0b055985353 (bumping all the dependency versions, in which the redis driver `carmine` was imported like a normal dep)

This (hopefully) last PR now aims at running cloujera in its very own container. Stay tuned.

Seriously tho. This thing needs tests. :stuck_out_tongue: 
