### PR TITLE
Fixed README to use docker logs command to display cloujera logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You should see `redis`, `elasticsearch` and `cloujera` running
 
 ```bash
 $ vagrant ssh
-$ sudo docker exec cloujera cat /var/cloujera.log
+$ sudo docker logs cloujera
 ```
 
 ### Checking elasticsearch health


### PR DESCRIPTION
I couldn't find any logs at /var/cloujera.log. I think we are printing them to stderr so we should be using docker logs command:

_"The docker logs command batch-retrieves logs present at the time of execution."_
