### PR TITLE
[RFC] Remove full transcripts in frontend

### DIFF
--- a/src/clj/cloujera/models/video.clj
+++ b/src/clj/cloujera/models/video.clj
@@ -1,17 +1,6 @@
 (ns cloujera.models.video
   (:require [schema.core :as s]))
 
-(def fake-video
-  {:id "29"
-   :title "Lecture 3 - Chapter 2: The industrial revolution starts in England"
-   :transcript "The world we've seen is divided...(no timestamps!!)"
-   :video-url "http://d396qusza40orc.cloudfront.net/susdev/recoded_videos%2Fsusdev_3_01.da6ff370809111e3af279b48f4519db4.webm"
-   :_link "https://class.coursera.org/susdev-002/lecture/29"
-   :course {:id "susdev-002"
-            :title "The Age of Sustainable Development"
-            :_link "https://class.coursera.org/susdev-002"}})
-
-
 (def Course
   "The schema for a Coursera Course (embedded in a video)"
   {:id s/Str

--- a/src/clj/cloujera/models/video.clj
+++ b/src/clj/cloujera/models/video.clj
@@ -14,7 +14,7 @@
   "The schema for a Coursera Video"
   {:id s/Str
    :title s/Str
-   :transcript s/Str
+   (s/optional-key :transcript) s/Str
    (s/optional-key :highlighted-transcript) s/Str
    :video-url s/Str
    :_link s/Str

--- a/src/clj/cloujera/search/core.clj
+++ b/src/clj/cloujera/search/core.clj
@@ -24,10 +24,12 @@
 
 (defn- extract-video-result [elastic-video]
   (let [video (:_source elastic-video)
-        elastic-highlight (get-in elastic-video [:highlight :transcript])]
-    (assoc video
-           :highlighted-transcript
-           (elastic-highlight->highlighted-transcript elastic-highlight))))
+        elastic-highlight (get-in elastic-video [:highlight :transcript])
+        hl-transcript (elastic-highlight->highlighted-transcript elastic-highlight)
+        video+hl-transcript (assoc video
+                                   :highlighted-transcript
+                                   hl-transcript)]
+    (dissoc video :transcript)))
 
 (defn- extract-results [videos]
   (let [found-videos (get-in videos [:hits :hits])]


### PR DESCRIPTION
Save bandwidth by not sending the full `:transcript` to the frontend

(only `:highlighted-transcript` is needed... and `:transcript`s can be very big..)
