### PR TITLE
[RFC] Remove HTTP calls at complile time

### DIFF
--- a/src/clj/cloujera/burglar/core.clj
+++ b/src/clj/cloujera/burglar/core.clj
@@ -11,9 +11,6 @@
 (def password "letswinthisthing")
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-;; FIXME: this makes an HTTP call at *compile* time
-;; that means that if the session expires, you need to recompile
-;; compilation/deployment can also fail if the network is flaky
 (def get-coursera-page
   (cache/persist (scraper/get-protected-page username password)))
 


### PR DESCRIPTION
Only perform the HTTP call to coursera.org on the first call of the fn returned by `get-protected-page`
