### PR TITLE
[RFC] Reload app in dev mode

### DIFF
--- a/profiles.clj
+++ b/profiles.clj
@@ -4,5 +4,6 @@
 
 ;; we define :elasticsearch-port and :redis-port with weird names and format
 ;; because that's the the ones Docker exports in linked containers
-{:dev {:env {:elasticsearch-port "tcp://127.0.0.1:9200"
+{:dev {:main cloujera.core/-dev-main
+       :env {:elasticsearch-port "tcp://127.0.0.1:9200"
              :redis-port "tcp://127.0.0.1:6379"}}}

--- a/project.clj
+++ b/project.clj
@@ -39,8 +39,6 @@
                           :output-dir "resources/public/js/out"
                           :optimizations :none
                           :source-map true}}]}
-  :main ^:skip-aot cloujera.core
+  :main cloujera.core
   :target-path "target/%s"
-  :profiles {:uberjar {:aot :all}}
-             :dev {:dependencies [[javax.servlet/servlet-api "2.5"]
-                                  [ring-mock "0.1.5"]]})
+  :profiles {:uberjar {:aot :all}})

--- a/src/clj/cloujera/core.clj
+++ b/src/clj/cloujera/core.clj
@@ -2,7 +2,8 @@
   (:require [cloujera.routes :as routes]
             [compojure.handler :as handler]
             [org.httpkit.server :as server]
-            [ring.middleware.json :as middleware])
+            [ring.middleware.json :as middleware]
+            [ring.middleware.reload :as reload])
   (:gen-class))
 
 (def app
@@ -14,3 +15,8 @@
   (do
     (println "Listening on port 8080...")
     (server/run-server app {:port 8080})))
+
+(defn -dev-main []
+  (do
+    (println "DEV-SERVER: Listening on port 8080...")
+    (server/run-server (reload/wrap-reload #'app) {:port 8080})))


### PR DESCRIPTION
Reload app when using the dev profile(e.g. when doing `lein run`).

In dev, the app now uses `cloujera.core/-dev-main` as the main entrypoint. `-dev-main` wraps the app with `ring.middleware.reload/wrap-reload`  which reloads files as needed.

**NOTE**: any profiles specified _both_ in `project.clj` _and_ `profiles.clj` will be overridden by the latter. (So there's no point in having a `:dev` profile in `project.clj`...)
